### PR TITLE
Update Fech dependency to 1.8 and added some methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     fech-search (0.1.0)
       fech (~> 1.8)
-      nokogiri (= 1.6.6.2)
+      nokogiri (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
@@ -15,10 +15,12 @@ GEM
       ensure-encoding
       fastercsv
       people
-    mini_portile (0.6.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     people (0.2.1)
+    pkg-config (1.1.7)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,23 @@
 PATH
   remote: .
   specs:
-    fech-search (0.0.1)
-      fech (= 1.4.1)
+    fech-search (0.1.0)
+      fech (~> 1.8)
+      nokogiri (= 1.6.6.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
+    ensure-encoding (0.1)
     fastercsv (1.5.5)
-    fech (1.4.1)
+    fech (1.8)
+      ensure-encoding
       fastercsv
       people
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     people (0.2.1)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
@@ -27,4 +33,7 @@ PLATFORMS
 
 DEPENDENCIES
   fech-search!
-  rspec (= 2.13.0)
+  rspec (~> 2.13.0)
+
+BUNDLED WITH
+   1.10.5

--- a/fech-search.gemspec
+++ b/fech-search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Fech::Search::VERSION
 
   gem.add_dependency "fech", "~> 1.8"
-  gem.add_dependency "nokogiri", "1.6.6.2"
+  gem.add_dependency "nokogiri", "~> 1.6"
 
   gem.add_development_dependency "rspec", "~> 2.13.0"
 end

--- a/fech-search.gemspec
+++ b/fech-search.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Fech::Search::VERSION
 
-  gem.add_dependency "fech", "~> 1.6.2"
+  gem.add_dependency "fech", "~> 1.8"
   gem.add_dependency "nokogiri", "1.6.6.2"
 
   gem.add_development_dependency "rspec", "~> 2.13.0"

--- a/lib/fech-search/search.rb
+++ b/lib/fech-search/search.rb
@@ -93,7 +93,7 @@ module Fech
     # Parse a line that contains committee information
     def parse_committee_line(line)
       match = line.match(/<A.*?>(?<name>.*?) - (?<id>C\d{8})<\/A/)
-      {:committee_name => match['name'], :committee_id => match['id']}
+      {committee_name: match['name'], committee_id: match['id']}
     end
 
     # Parse a line that contains a filing
@@ -107,4 +107,3 @@ module Fech
   end
 
 end
-


### PR DESCRIPTION
Adds an `amendment` boolean attribute to indicate a filing is an amendment, plus adds filing description for form types that don't have it (F1, F2, a few others).
